### PR TITLE
improve performance for getambassador.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 
 log*.txt
 *.log
+/.idea/

--- a/broken_links_to_csv.py
+++ b/broken_links_to_csv.py
@@ -1,0 +1,66 @@
+import csv
+import sys
+from typing import List
+
+BROKEN_LINK_MESSAGE = "has a broken link: "
+
+
+class BrokenLink:
+    source: str = ''
+    link: str = ''
+    options: str = ''
+    comments: str = ''
+
+    def __init__(self, source: str, link: str, options: str = '', comments: str = ''):
+        self.source = source
+        self.link = link
+        self.options = options
+        self.comments = comments
+
+    def to_csv(self):
+        return [self.source, self.link, self.options, self.comments]
+
+
+def print_usage():
+    print(f"Usage: {sys.argv[0]} BLC_LOG_FILE", file=sys.stderr)
+
+
+def is_a_broken_link(line: str) -> bool:
+    return BROKEN_LINK_MESSAGE in line
+
+
+def parse_broken_link(line: str) -> BrokenLink:
+    line = line.replace(BROKEN_LINK_MESSAGE, '')
+    line = line.replace('Page ', '')
+    line = line.rstrip()
+    tokens = line.split(' ', 2)
+    return BrokenLink(source=tokens[0], link=tokens[1], options=tokens[2])
+
+
+def write_to_csv_file(broken_links: List):
+    with open('blc.csv', mode='w') as blc_file:
+        blc_writer = csv.writer(blc_file, delimiter=';', quotechar="'")
+        blc_writer.writerow(['SOURCE', 'DESTINY', 'OPTIONS', 'COMMENTS'])
+        blc_writer.writerows([broken_link.to_csv() for broken_link in broken_links])
+
+
+def main(blc_log_path):
+    broken_links: List = list()
+    try:
+        file = open(blc_log_path)
+        while line := file.readline():
+            if is_a_broken_link(line):
+                broken_links.append(parse_broken_link(line))
+        write_to_csv_file(broken_links)
+        return 0
+    except Exception as error:
+        print(error)
+        return 3
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print_usage()
+        sys.exit(2)
+    else:
+        sys.exit(main(sys.argv[1]))

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -39,13 +39,13 @@ class AmbassadorChecker(GenericChecker):
 
     def product_should_skip_link(self, link: Link) -> bool:
         return link.linkurl.ref in [
+            'http://verylargejavaservice:8080',
             'https://blog.getambassador.io/search?q=canary',
             'https://app.datadoghq.com/apm/traces',
             'http://web-app.emojivoto',
             'http://localhost:8080',
             'http://localhost:8083',
             'http://verylargejavaservice.default:8080',
-            'http://verylargejavaservice:8080',
         ]
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -38,15 +38,18 @@ class AmbassadorChecker(GenericChecker):
         return False
 
     def product_should_skip_link(self, link: Link) -> bool:
-        return link.linkurl.ref in [
+        links_to_skip = [
             'http://verylargejavaservice:8080',
             'https://blog.getambassador.io/search?q=canary',
             'https://app.datadoghq.com/apm/traces',
-            'http://web-app.emojivoto',
-            'http://localhost:8080',
-            'http://localhost:8083',
-            'http://verylargejavaservice.default:8080',
+            'http://web-app.emojivoto/',
+            'http://web-app.emojivoto/leaderboard',
+            'http://verylargejavaservice.default:8080/color',
+            'http://localhost:8080/',
+            'http://localhost:8083/',
+            'http://verylargejavaservice.default:8080/',
         ]
+        return link.linkurl.ref in links_to_skip or 'mailto' in link.linkurl.ref
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -45,7 +45,7 @@ class AmbassadorChecker(GenericChecker):
             'http://localhost:8080',
             'http://localhost:8083',
             'http://verylargejavaservice.default:8080',
-            'http://verylargejavaservice:8080'
+            'http://verylargejavaservice:8080',
         ]
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -23,17 +23,6 @@ def urlpath(url: str) -> str:
     return urlparse(url).path
 
 
-links_to_skip = [
-    'https://blog.getambassador.io/search?q=canary',
-    'https://app.datadoghq.com/apm/traces',
-    'http://web-app.emojivoto',
-    'http://localhost:8080',
-    'http://localhost:8083',
-    'http://verylargejavaservice.default:8080',
-    'http://verylargejavaservice:8080'
-]
-
-
 class AmbassadorChecker(GenericChecker):
     def is_internal_domain(self, netloc: str) -> bool:
         if netloc == 'blog.getambassador.io':
@@ -49,7 +38,15 @@ class AmbassadorChecker(GenericChecker):
         return False
 
     def product_should_skip_link(self, link: Link) -> bool:
-        return link.linkurl.ref in links_to_skip
+        return link.linkurl.ref in [
+            'https://blog.getambassador.io/search?q=canary',
+            'https://app.datadoghq.com/apm/traces',
+            'http://web-app.emojivoto',
+            'http://localhost:8080',
+            'http://localhost:8083',
+            'http://verylargejavaservice.default:8080',
+            'http://verylargejavaservice:8080'
+        ]
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -23,9 +23,22 @@ def urlpath(url: str) -> str:
     return urlparse(url).path
 
 
+links_to_skip = [
+    'https://blog.getambassador.io/search?q=canary',
+    'https://app.datadoghq.com/apm/traces',
+    'http://web-app.emojivoto',
+    'http://localhost:8080',
+    'http://localhost:8083',
+    'http://verylargejavaservice.default:8080',
+    'http://verylargejavaservice:8080'
+]
+
+
 class AmbassadorChecker(GenericChecker):
     def is_internal_domain(self, netloc: str) -> bool:
         if netloc == 'blog.getambassador.io':
+            return False
+        if netloc == 'app.getambassador.io':
             return False
         if netloc == 'getambassador.io':
             return True
@@ -36,9 +49,7 @@ class AmbassadorChecker(GenericChecker):
         return False
 
     def product_should_skip_link(self, link: Link) -> bool:
-        return (link.linkurl.ref == 'https://blog.getambassador.io/search?q=canary') or (
-            link.linkurl.ref == 'https://app.datadoghq.com/apm/traces'
-        )
+        return link.linkurl.ref in links_to_skip
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(
@@ -75,9 +86,9 @@ class AmbassadorChecker(GenericChecker):
                 self.log_ugly(
                     link=link,
                     reason='is a canonical but does not point at www.getambassador.io',
-                    suggestion=urlparse(link.linkurl.resolved)
-                    ._replace(scheme='https', netloc='www.getambassador.io')
-                    .geturl(),
+                    suggestion=urlparse(link.linkurl.resolved)._replace(
+                        scheme='https',
+                        netloc='www.getambassador.io').geturl(),
                 )
             # Other than that, the canonicals don't need to be inspected more, because they're
             # allowed (expected!) to be cross-version.

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -86,9 +86,9 @@ class AmbassadorChecker(GenericChecker):
                 self.log_ugly(
                     link=link,
                     reason='is a canonical but does not point at www.getambassador.io',
-                    suggestion=urlparse(link.linkurl.resolved)._replace(
-                        scheme='https',
-                        netloc='www.getambassador.io').geturl(),
+                    suggestion=urlparse(link.linkurl.resolved)
+                    ._replace(scheme='https', netloc='www.getambassador.io')
+                    .geturl(),
                 )
             # Other than that, the canonicals don't need to be inspected more, because they're
             # allowed (expected!) to be cross-version.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=15.0.0"
   },
   "dependencies": {
+    "fdir": "^5.1.0",
     "mime": "^2.5.2",
     "netlify-cli": "^4.0.5",
     "netlify-redirect-parser": "^5.1.1"

--- a/serve.js
+++ b/serve.js
@@ -7,12 +7,26 @@ const url = require('url');
 
 const mime = require('mime');
 const redirectParser = require('netlify-redirect-parser');
-const { parseHeadersFile, headersForPath } = require('netlify-cli/src/utils/headers');
+const {
+  parseHeadersFile,
+  headersForPath
+} = require('netlify-cli/src/utils/headers');
+const {fdir} = require('fdir');
 
 let host = 'localhost';
 let port = 9000;
 let dir = path.resolve('public');
 let cfg = path.resolve('netlify.toml');
+
+// getambassador.io migration sources
+const datawireDomains = {
+  'http://www.datawire.io/': true,
+  'https://www.datawire.io/': true,
+  'http://datawire.io/': true,
+  'https://datawire.io/': true
+};
+// getambassador.io migration link
+const migrationRedirect = 'https://www.getambassador.io/?utm_source=https://www.datawire.io/';
 
 const server = http.createServer();
 
@@ -27,6 +41,11 @@ async function exists(filepath) {
 
 function matchesRedirect(forcefulOnly, requestURL, redirect) {
   if (forcefulOnly && !redirect.force) {
+    return false;
+  }
+  // keep getambassador.io on localhost, due to migrations from datawire.io to getambassador.io
+  if (requestURL.pathname === '/' && requestURL.path === '/' && requestURL.href === '/' &&
+    datawireDomains[redirect.origin] && migrationRedirect === redirect.to) {
     return false;
   }
   if (redirect.path !== requestURL.pathname && redirect.path !== requestURL.pathname+'/') {
@@ -44,13 +63,42 @@ function matchesRedirect(forcefulOnly, requestURL, redirect) {
 function doRedirect(requestURL, response, redirect) {
   let location = redirect.to;
   if (!url.parse(location).search) {
-    location += (requestURL.search||'');
+    location += (requestURL.search || '');
   }
   response.writeHead(redirect.status, {
     'Location': location,
     'Content-Type': 'text/plain',
   });
   response.end(`Redirecting to ${location}`);
+}
+
+const filesOnMemory = {};
+const errorLoadingFile = 'There was reading the file';
+
+function loadSiteOnMemory(dir) {
+  const api = new fdir().withFullPaths().crawl(dir);
+  const files = api.sync();
+  for (const file of files) {
+    fs.readFile(file).then(content => {
+      filesOnMemory[file] = content;
+    }).catch(() => filesOnMemory[file] = errorLoadingFile);
+  }
+}
+
+loadSiteOnMemory(dir);
+
+const headersFiles = [path.resolve('_headers'), path.resolve(dir, '_headers')];
+const headerRules = headersFiles.reduce((headerRules, headersFile) => Object.assign(headerRules, parseHeadersFile(headersFile)), {});
+
+let redirects;
+
+try {
+  redirects = redirectParser.parseAllRedirects({
+    redirectsFiles: [path.resolve(dir, '_redirects')],
+    netlifyConfigPath: cfg,
+  });
+} catch (err) {
+  process.abort();
 }
 
 server.on('request', async (request, response) => {
@@ -61,20 +109,7 @@ server.on('request', async (request, response) => {
     response.end('Bad request URL');
   }
 
-  let redirects;
-  try {
-    redirects = await redirectParser.parseAllRedirects({
-      redirectsFiles: [path.resolve(dir, '_redirects')],
-      netlifyConfigPath: cfg,
-    });
-  } catch (err) {
-    response.writeHead(500, {
-      'Content-Type': 'application/json',
-    });
-    response.end(JSON.stringify(err));
-    return;
-  }
-  let redirect = redirects.find((redirect)=>(matchesRedirect(true, requestURL, redirect)));
+  let redirect = (await redirects).find((redirect) => (matchesRedirect(true, requestURL, redirect)));
   if (redirect) {
     doRedirect(requestURL, response, redirect);
     return;
@@ -83,11 +118,15 @@ server.on('request', async (request, response) => {
   const filepath = path.join(dir, requestURL.pathname).replace(/\/$/, '/index.html');
   let content;
   try {
-    content = await fs.readFile(filepath);
+    if (filesOnMemory[filepath] && filesOnMemory[filepath] !== errorLoadingFile) {
+      content = filesOnMemory[filepath];
+    } else {
+      content = await fs.readFile(filepath);
+    }
   } catch (err) {
     if (err.code === 'EISDIR' && !requestURL.pathname.endsWith('/')) {
       // All sane webservers should do this.  `netlify dev` doesn't.
-      const location = requestURL.pathname + '/' + (requestURL.search||'');
+      const location = requestURL.pathname + '/' + (requestURL.search || '');
       response.writeHead(302, {
         'Location': location,
         'Content-Type': 'text/plain',
@@ -96,13 +135,13 @@ server.on('request', async (request, response) => {
     } else if (requestURL.pathname.endsWith('.html') && await exists(filepath.replace(/\.html$/, ''))) {
       // This is a weird thing that Netlify does (even if you
       // turn off pretty URLs).
-      const location = requestURL.pathname.replace(/\.html$/, '') + (requestURL.search||'');
+      const location = requestURL.pathname.replace(/\.html$/, '') + (requestURL.search || '');
       response.writeHead(302, {
         'Location': location,
         'Content-Type': 'text/plain',
       });
       response.end(`Redirecting to ${location}`);
-    } else if ((redirect = redirects.find((redirect)=>(matchesRedirect(false, requestURL, redirect))))) {
+    } else if ((redirect = (await redirects).find((redirect) => (matchesRedirect(false, requestURL, redirect))))) {
       doRedirect(requestURL, response, redirect);
     } else {
       response.writeHead(404, {
@@ -113,8 +152,6 @@ server.on('request', async (request, response) => {
     return;
   }
 
-  const headersFiles = [path.resolve('_headers'), path.resolve(dir, '_headers')];
-  const headerRules = headersFiles.reduce((headerRules, headersFile) => Object.assign(headerRules, parseHeadersFile(headersFile)), {});
   const pathHeaderRules = headersForPath(headerRules, requestURL.pathname);
   Object.entries(pathHeaderRules).forEach(([key, val]) => {
     response.setHeader(key, val);

--- a/serve.js
+++ b/serve.js
@@ -73,7 +73,7 @@ function doRedirect(requestURL, response, redirect) {
 }
 
 const filesOnMemory = {};
-const errorLoadingFile = 'There was reading the file';
+const errorLoadingFile = 'There was an error reading the file';
 
 function loadSiteOnMemory(dir) {
   const api = new fdir().withFullPaths().crawl(dir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,6 +3813,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fdir@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-5.1.0.tgz#973e4934e6a3666b59ebdfc56f60bb8e9b16acb8"
+  integrity sha512-IgTtZwL52tx2wqWeuGDzXYTnNsEjNLahZpJw30hCQDyVnoHXwY5acNDnjGImTTL1R0z1PCyLw20VAbE5qLic3Q==
+
 fecha@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"


### PR DESCRIPTION
Prior to this PR the process of the full site takes more than five hours, with this PR the process takes around 90 minutes. We found a couple of bottlenecks on `server.js` files. The server was parsing the `_redirects` and `_headers` files in each request, even when these files don't change with any request. Now we parsed both files at the beginning and then the server starts serving requests. 

Also, there are some redirects of the migration from datawire to getambassador that was redirecting the request from `/` to `www.getambassador.io`, we added a condition to handle that on the `server.js` file.

Add a script to parse the result and get only the broken links, to use it you can run the script as follow:
```
python broken_links_to_csv.py $BLC_LOG_FILE
```
