### PR TITLE
this fix would be stop detecting sanity images with a rect attribute as broken links.

### DIFF
--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -207,6 +207,10 @@ class BaseChecker:
 
         return None
 
+    @staticmethod
+    def _parse_srcset_value(attrvalue: str) -> List:
+        return [desc.split()[0] for desc in attrvalue.split(',')]
+
     def _process_html(self, page_url: URLReference, page_soup: BeautifulSoup) -> None:
         # This list of selectors is the union of all lists in
         # https://github.com/stevenvachon/broken-link-checker/blob/master/lib/internal/tags.js
@@ -272,7 +276,7 @@ class BaseChecker:
                         url_strs = [x for x in attrvalue.split()]
                     elif attrname == 'srcset':
                         # https://html.spec.whatwg.org/multipage/images.html#srcset-attributes
-                        url_strs = [desc.split()[0] for desc in attrvalue.split(',')]
+                        url_strs = self._parse_srcset_value(attrvalue)
                     else:
                         url_strs = [attrvalue]
 

--- a/generic_blc.py
+++ b/generic_blc.py
@@ -23,6 +23,8 @@ class GenericChecker(BaseChecker):
     stats_links_total: int = 0
     stats_links_bad: int = 0
     stats_sleep: float = 0
+    stats_broken_links: int = 0
+    stats_ugly_links: int = 0
 
     stats_sitemap: Set[str] = set()
 

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -4,11 +4,11 @@ import re
 import subprocess
 import sys
 import threading
-from typing import Optional, List
-from urllib.parse import urlparse, urldefrag
+from typing import List, Optional
+from urllib.parse import urldefrag, urlparse
 
 from blclib import Link, URLReference
-from generic_blc import GenericChecker, CheckerInterface
+from generic_blc import CheckerInterface, GenericChecker
 
 
 def is_doc_url(url: URLReference) -> Optional[str]:
@@ -65,9 +65,11 @@ class AmbassadorChecker(GenericChecker):
             'http://localhost:8083/leaderboard/',
             'http://verylargejavaservice.default:8080/',
         ]
-        return len(
-            [True for link_to_skip in links_to_skip if link.linkurl.ref in link_to_skip]
-        ) > 0 or 'mailto' in link.linkurl.ref
+        return (
+            len([True for link_to_skip in links_to_skip if link.linkurl.ref in link_to_skip])
+            > 0
+            or 'mailto' in link.linkurl.ref
+        )
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(
@@ -138,7 +140,9 @@ class AmbassadorChecker(GenericChecker):
             tokens = attrvalue.split(',', 4)
             while len(tokens) >= 4:
                 links.append(delimiter.join(tokens[0:4]).split(' ')[0])
-                attrvalue = attrvalue[attrvalue.find('h', len(delimiter.join(tokens[0:4]))):]
+                attrvalue = attrvalue[
+                    attrvalue.find('h', len(delimiter.join(tokens[0:4]))):
+                ]
                 tokens = attrvalue.split(delimiter, 5)
             return links
         else:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -27,9 +27,6 @@ def urlpath(url: str) -> str:
 
 
 class AmbassadorChecker(GenericChecker):
-    stats_broken_links: int = 0
-    stats_ugly_links: int = 0
-
     def log_broken(self, link: Link, reason: str) -> None:
         self.stats_broken_links += 1
         msg = f'Page {urldefrag(link.pageurl.resolved).url} has a broken link: "{link.linkurl.ref}" ({reason})'
@@ -108,8 +105,8 @@ class AmbassadorChecker(GenericChecker):
                     link=link,
                     reason='is a canonical but does not point at www.getambassador.io',
                     suggestion=urlparse(link.linkurl.resolved)
-                        ._replace(scheme='https', netloc='www.getambassador.io')
-                        .geturl(),
+                    ._replace(scheme='https', netloc='www.getambassador.io')
+                    .geturl(),
                 )
             # Other than that, the canonicals don't need to be inspected more, because they're
             # allowed (expected!) to be cross-version.

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
+import os
 import re
+import subprocess
 import sys
-from typing import Optional
-from urllib.parse import urlparse
+import threading
+from typing import Optional, List
+from urllib.parse import urlparse, urldefrag
 
 from blclib import Link, URLReference
-from generic_blc import GenericChecker, main
+from generic_blc import GenericChecker, CheckerInterface
 
 
 def is_doc_url(url: URLReference) -> Optional[str]:
@@ -24,6 +27,21 @@ def urlpath(url: str) -> str:
 
 
 class AmbassadorChecker(GenericChecker):
+    stats_broken_links: int = 0
+    stats_ugly_links: int = 0
+
+    def log_broken(self, link: Link, reason: str) -> None:
+        self.stats_broken_links += 1
+        msg = f'Page {urldefrag(link.pageurl.resolved).url} has a broken link: "{link.linkurl.ref}" ({reason})'
+        print(msg)
+
+    def log_ugly(self, link: Link, reason: str, suggestion: Optional[str] = None) -> None:
+        self.stats_ugly_links += 1
+        msg = f'Page {urldefrag(link.pageurl.resolved).url} has an ugly link: "{link.linkurl.ref}" {reason}'
+        if suggestion:
+            msg += f' (did you mean "{suggestion}"?)'
+        print(msg)
+
     def is_internal_domain(self, netloc: str) -> bool:
         if netloc == 'blog.getambassador.io':
             return False
@@ -39,17 +57,20 @@ class AmbassadorChecker(GenericChecker):
 
     def product_should_skip_link(self, link: Link) -> bool:
         links_to_skip = [
-            'http://verylargejavaservice:8080',
+            'http://verylargejavaservice:8080/',
             'https://blog.getambassador.io/search?q=canary',
-            'https://app.datadoghq.com/apm/traces',
+            'https://app.datadoghq.com/apm/traces/',
             'http://web-app.emojivoto/',
-            'http://web-app.emojivoto/leaderboard',
+            'http://web-app.emojivoto/leaderboard/',
             'http://verylargejavaservice.default:8080/color',
             'http://localhost:8080/',
             'http://localhost:8083/',
+            'http://localhost:8083/leaderboard/',
             'http://verylargejavaservice.default:8080/',
         ]
-        return link.linkurl.ref in links_to_skip or 'mailto' in link.linkurl.ref
+        return len(
+            [True for link_to_skip in links_to_skip if link.linkurl.ref in link_to_skip]
+        ) > 0 or 'mailto' in link.linkurl.ref
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(
@@ -87,8 +108,8 @@ class AmbassadorChecker(GenericChecker):
                     link=link,
                     reason='is a canonical but does not point at www.getambassador.io',
                     suggestion=urlparse(link.linkurl.resolved)
-                    ._replace(scheme='https', netloc='www.getambassador.io')
-                    .geturl(),
+                        ._replace(scheme='https', netloc='www.getambassador.io')
+                        .geturl(),
                 )
             # Other than that, the canonicals don't need to be inspected more, because they're
             # allowed (expected!) to be cross-version.
@@ -111,6 +132,61 @@ class AmbassadorChecker(GenericChecker):
                     link=link,
                     reason=f'is a link from docs version={src_ver} to docs version={dst_ver}',
                 )
+
+    @staticmethod
+    def _parse_srcset_value(attrvalue: str) -> List:
+        delimiter = ','
+        if "&rect=" in attrvalue and "https://cdn.sanity.io/images/" in attrvalue:
+            links = []
+            tokens = attrvalue.split(',', 4)
+            while len(tokens) >= 4:
+                links.append(delimiter.join(tokens[0:4]).split(' ')[0])
+                attrvalue = attrvalue[attrvalue.find('h', len(delimiter.join(tokens[0:4]))):]
+                tokens = attrvalue.split(delimiter, 5)
+            return links
+        else:
+            return [desc.split()[0] for desc in attrvalue.split(',')]
+
+
+def main(checkerCls: CheckerInterface, projdir: str) -> int:
+    urls = [
+        'http://localhost:9000/summer-of-k8s/code/',
+    ]
+    checker = checkerCls(domain=urlparse(urls[0]).netloc)
+    for url in urls:
+        checker.enqueue(URLReference(ref=url))
+
+    with subprocess.Popen(
+        [os.path.join(os.path.dirname(__file__), 'serve.js')],
+        cwd=projdir,
+        stdout=subprocess.PIPE,
+    ) as srv:
+        try:
+            # Wait for the server to be ready
+            assert srv.stdout
+            sys.stdout.write(srv.stdout.readline().decode('utf-8'))
+
+            # Pump the servers logs
+            def pump():
+                while line := srv.stdout.readline():
+                    sys.stdout.write(line.decode('utf-8'))
+
+            threading.Thread(target=pump).start()
+
+            # Run the checker
+            checker.run()
+        finally:
+            srv.kill()
+
+    # Print a summary
+    print("Summary:")
+    print(
+        f"  Actions: Sent {checker.stats_requests} HTTP requests and slept for {checker.stats_sleep} seconds in order to check {checker.stats_links_total} links on {checker.stats_pages} pages."
+    )
+    print(
+        f"  Results: Encountered {checker.stats_ugly_links + checker.stats_broken_links} errors, {checker.stats_links_bad} bad links."
+    )
+    return 1 if checker.stats_broken_links > 0 else 0
 
 
 if __name__ == "__main__":

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -141,7 +141,7 @@ class AmbassadorChecker(GenericChecker):
             while len(tokens) >= 4:
                 links.append(delimiter.join(tokens[0:4]).split(' ')[0])
                 attrvalue = attrvalue[
-                    attrvalue.find('h', len(delimiter.join(tokens[0:4]))):
+                    attrvalue.find('h', len(delimiter.join(tokens[0:4]))) :
                 ]
                 tokens = attrvalue.split(delimiter, 5)
             return links


### PR DESCRIPTION
Prior to this PR some images from sanity were detected as a broken link due to a poor parse process on the checker. With this PR we add a specific case for the getambassador.io parser.