### PR TITLE
add www.getambassador.io/*/ to links to skip

### DIFF
--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -64,6 +64,7 @@ class AmbassadorChecker(GenericChecker):
             'http://localhost:8083/',
             'http://localhost:8083/leaderboard/',
             'http://verylargejavaservice.default:8080/',
+            'https://www.getambassador.io/*/',
         ]
         return (
             len([True for link_to_skip in links_to_skip if link.linkurl.ref in link_to_skip])


### PR DESCRIPTION
Prior to this PR the link `www.getambassador.io/*/` is detected as a broken link, with this PR we are not visiting the link. At this point, we don't know the source of the link but it isn't breaking the user experience.