### PR TITLE
Aglez/dev/add user agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ or
 TARGET=~/src/other-thing.tld make -C ~/src/blc2 > blc.log
 ```
 
+or
+
+```shell
+TARGET=~/src/getambassador.io PRODUCT=getambassadorio USER_AGENT=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36 make -C ~/src/blc2 > blc.log
+```
+
 Then `tail blc.log` for a summary, or `grep ^Page blc.log` for a list
 of pages with broken links.
 
@@ -28,6 +34,8 @@ of pages with broken links.
  - `PRODUCT` (default=`generic`):
    + Specific per-product link checks settings are defined in
      `${PRODUCT}_blc.py` files.
+ - `USER_AGENT` (default: `github.com/datawire/getambassador.io-blc2`; not required to be set):
+    + Specifies the `User_Agent` header value for each request. It avoids security blocks from external sites
 
 # Why
 

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -1,3 +1,4 @@
+import os
 import re
 import time
 from http.client import HTTPMessage
@@ -14,6 +15,8 @@ from .data_uri import DataAdapter
 from .httpcache import HTTPClient as BaseHTTPClient
 from .httpcache import RetryAfterException
 from .models import Link, URLReference
+
+USER_AGENT = os.getenv('USER_AGENT', 'github.com/datawire/getambassador.io-blc2')
 
 
 def get_content_type(resp: requests.Response) -> str:
@@ -146,7 +149,7 @@ class BaseChecker:
             resp: requests.Response = self._client.get(
                 url,
                 headers={
-                    'User-Agent': 'github.com/datawire/getambassador.io-blc2',
+                    'User-Agent': USER_AGENT,
                 },
             )
             if resp.status_code != 200:


### PR DESCRIPTION
Before this PR, the broken link checker for getambassador.io only used the User-Agent value `github.com/datawire/getambassador.io-blc2`, hence, some links are detected as broken links due to security issues on external sites. Now we can set a different value for the User-Agent to avoid security on external sites. 