### PR TITLE
Aglez/dev/add timeout on the request

### DIFF
--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -151,6 +151,7 @@ class BaseChecker:
                 headers={
                     'User-Agent': USER_AGENT,
                 },
+                timeout=10,
             )
             if resp.status_code != 200:
                 reterr = f"HTTP_{resp.status_code}"

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -190,7 +190,7 @@ def main(checkerCls: CheckerInterface, projdir: str) -> int:
     print(
         f"  Results: Encountered {checker.stats_ugly_links + checker.stats_broken_links} errors, {checker.stats_links_bad} bad links."
     )
-    return 1 if checker.stats_broken_links > 0 else 0
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before this PR the broken link checker blocks with some external requests (more precisely with this one `https://java.com/en/download/help/download_options.html`). The `get` request method adds a 10 seconds timeout to avoid the blocker and continue with the process. If a link reaches the timeout condition, it will handle as a broken link.