### PR TITLE
handle the timeout from a request as a special error

### DIFF
--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -166,7 +166,7 @@ class BaseChecker:
             return resp
         except RetryAfterException as err:
             raise err
-        except requests.exceptions.Timeout as err:
+        except requests.exceptions.Timeout:
             reterr = f"HTTP_TIMEOUT"
             self.handle_page_error(url, reterr)
             return reterr

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -166,6 +166,10 @@ class BaseChecker:
             return resp
         except RetryAfterException as err:
             raise err
+        except requests.exceptions.Timeout as err:
+            reterr = f"HTTP_TIMEOUT"
+            self.handle_page_error(url, reterr)
+            return reterr
         except Exception as err:
             reterr = f"{err}"
             self.handle_page_error(url, reterr)
@@ -330,7 +334,10 @@ class BaseChecker:
             page_clean_url = urldefrag(page_url.resolved).url
             self._done_pages.add(page_clean_url)
             self.handle_page_starting(page_clean_url)
-            self.handle_page_error(page_clean_url, page_resp)
+            if page_resp == "HTTP_TIMEOUT":
+                self.handle_timeout(page_clean_url, page_resp)
+            else:
+                self.handle_page_error(page_clean_url, page_resp)
             return
         page_urls = set(urldefrag(r.url).url for r in ([page_resp] + page_resp.history))
         page_url = page_url._replace(resolved=page_resp.url)
@@ -473,6 +480,13 @@ class BaseChecker:
         links on.  This could be because we failed to fetch the page,
         or it could be because of an HTML-parsing error.
 
+        """
+        pass
+
+    def handle_timeout(self, url: str, err: str) -> None:
+        """handle_timeout is a hook; called whenever we encounter an http timeout error.
+        This could be because the user agent or the ip address is not allowed
+        by the remote site
         """
         pass
 

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -167,7 +167,7 @@ class BaseChecker:
         except RetryAfterException as err:
             raise err
         except requests.exceptions.Timeout:
-            reterr = f"HTTP_TIMEOUT"
+            reterr = "HTTP_TIMEOUT"
             self.handle_page_error(url, reterr)
             return reterr
         except Exception as err:

--- a/generic_blc.py
+++ b/generic_blc.py
@@ -68,6 +68,10 @@ class GenericChecker(BaseChecker):
         self.stats_errors += 1
         print(f"error: {url}: {err}")
 
+    def handle_timeout(self, url: str, err: str) -> None:
+        self.stats_errors += 1
+        print(f"Page {url} produced a timeout error. A manual review is required")
+
     def handle_429(self, err: RetryAfterException) -> None:
         print(f"backoff: {err.url}: retrying after {err.retry_after} seconds")
 

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -29,8 +29,9 @@ def urlpath(url: str) -> str:
 class AmbassadorChecker(GenericChecker):
     _user_agent_for_link: Dict[str, str] = {
         "https://www.ticketmaster.com/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
-        "https://java.com/en/download/help/download_options.html": "PostmanRuntime/7.28.4",
-        "https://java.com/en/download/": "PostmanRuntime/7.28.4",
+        "https://java.com/en/download/help/download_options.html": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+        "https://java.com/en/download/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://tanzu.vmware.com/kubernetes-grid": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
     }
 
     def log_broken(self, link: Link, reason: str) -> None:


### PR DESCRIPTION
Prior to this PR when a request has a timeout error, it was handled as a broken link, with this PR we add a handler for this kind of link. After the job gets completed, these links must be tested by hand.