### PR TITLE
Add handler for http timeout to avoid broken links

### DIFF
--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -233,7 +233,9 @@ class AmbassadorChecker(GenericChecker):
 
 def main(checkerCls: CheckerInterface, projdir: str) -> int:
     urls = [
-        'http://localhost:9000/docs/telepresence/pre-release/quick-start/qs-java/',
+        'http://localhost:9000/',
+        'http://localhost:9000/404.html',
+        'http://localhost:9000/404/',
     ]
     checker = checkerCls(domain=urlparse(urls[0]).netloc)
     for url in urls:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -107,51 +107,6 @@ class AmbassadorChecker(GenericChecker):
     def handle_link(self, link: Link) -> None:
         if not link_manually_checked(link):
             super(AmbassadorChecker, self).handle_link(link)
-        if not self.product_should_skip_link(link):
-            # Check if this link is broken.
-            url = urlparse(link.linkurl.resolved)
-            if link.linkurl.ref.endswith(".eot?#iefix"):
-                link = link._replace(
-                    linkurl=link.linkurl._replace(ref=link.linkurl.ref[: -len("?#iefix")])
-                )
-            elif (
-                url.netloc == 'github.com'
-                and re.search(r'^/[^/]+/[^/]+$', url.path)
-                and url.fragment
-                and not url.fragment.startswith('user-content-')
-            ):
-                link = link._replace(
-                    linkurl=link.linkurl._replace(
-                        resolved=url._replace(
-                            fragment='user-content-' + url.fragment
-                        ).geturl()
-                    )
-                )
-            elif (
-                url.netloc == 'github.com'
-                and re.search(r'^/[^/]+/[^/]+/blob/', url.path)
-                and re.search(r'^L[0-9]+-L[0-9]+$', url.fragment)
-            ):
-                self.enqueue(
-                    link._replace(
-                        linkurl=link.linkurl._replace(
-                            resolved=url._replace(
-                                fragment=url.fragment.split('-')[0]
-                            ).geturl()
-                        )
-                    )
-                )
-                self.enqueue(
-                    link._replace(
-                        linkurl=link.linkurl._replace(
-                            resolved=url._replace(
-                                fragment=url.fragment.split('-')[1]
-                            ).geturl()
-                        )
-                    )
-                )
-                return
-            self.enqueue(link)
 
     def product_should_skip_link_result(self, link: Link, broken: str) -> bool:
         return bool(

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -36,8 +36,13 @@ def link_manually_checked(link: Link) -> bool:
         "https://java.com/en/download/help/download_options.html",
     ]
     return (
-        len([True for link_to_skip in links_to_check_manually if
-             link.linkurl.ref in link_to_skip])
+        len(
+            [
+                True
+                for link_to_skip in links_to_check_manually
+                if link.linkurl.ref in link_to_skip
+            ]
+        )
         > 0
     )
 


### PR DESCRIPTION
Prior to this PR, the HTTP_TIMEOUT errors has treated as broken links. With this PR, we add a list of links to skip but they should be manually validated