### PR TITLE
add a mechanism for check only some specific pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PRODUCT ?= generic
 run: requirements.txt.stamp
-	. ./venv/bin/activate && PYTHONUNBUFFERED=y ./$(PRODUCT)_blc.py '$(TARGET)'
+	. ./venv/bin/activate && PYTHONUNBUFFERED=y ./$(PRODUCT)_blc.py '$(TARGET)' '$(PAGES_TO_CHECK)'
 .PHONY: run
 
 # lint

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ of pages with broken links.
      `${PRODUCT}_blc.py` files.
  - `USER_AGENT` (default: `github.com/datawire/getambassador.io-blc2`; not required to be set):
     + Specifies the `User_Agent` header value for each request. It avoids security blocks from external sites
+ - `PAGES_TO_CHECK` (not required to be set):
+    + Specifies the
 
 # Why
 

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -128,10 +128,7 @@ class BaseChecker:
                     elif isinstance(task, URLReference):
                         if len(self.pages_to_check) == 0:
                             self._check_page(task)
-                        elif (
-                            len(self.pages_to_check) > 0
-                            and task.resolved in self.pages_to_check
-                        ):
+                        elif task.resolved in self.pages_to_check:
                             self._check_page(task)
                     else:
                         assert False

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -87,6 +87,7 @@ class BaseChecker:
     _queued_pages: Set[str] = set()
     _done_pages: Set[str] = set()
     _user_agent_for_link: Dict[str, str] = dict()
+    pages_to_check: List[str] = []
 
     def __init__(self) -> None:
         self._client = HTTPClient(self)
@@ -125,7 +126,10 @@ class BaseChecker:
                     if isinstance(task, Link):
                         self._check_link(task)
                     elif isinstance(task, URLReference):
-                        self._check_page(task)
+                        if len(self.pages_to_check) == 0:
+                            self._check_page(task)
+                        elif len(self.pages_to_check) > 0 and task.resolved in self.pages_to_check:
+                            self._check_page(task)
                     else:
                         assert False
                 except RetryAfterException as err:

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -128,7 +128,10 @@ class BaseChecker:
                     elif isinstance(task, URLReference):
                         if len(self.pages_to_check) == 0:
                             self._check_page(task)
-                        elif len(self.pages_to_check) > 0 and task.resolved in self.pages_to_check:
+                        elif (
+                            len(self.pages_to_check) > 0
+                            and task.resolved in self.pages_to_check
+                        ):
                             self._check_page(task)
                     else:
                         assert False

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -9,6 +9,7 @@ from urllib.parse import urldefrag, urlparse
 
 from blclib import Link, URLReference
 from generic_blc import CheckerInterface, GenericChecker
+from utils.read_input_pages import ReadInputPages
 
 
 def is_doc_url(url: URLReference) -> Optional[str]:
@@ -186,13 +187,20 @@ class AmbassadorChecker(GenericChecker):
             return [desc.split()[0] for desc in attrvalue.split(',')]
 
 
-def main(checkerCls: CheckerInterface, projdir: str) -> int:
+def main(checkerCls: CheckerInterface, projdir: str, pages_to_check_file: str) -> int:
     urls = [
         'http://localhost:9000/',
         'http://localhost:9000/404.html',
         'http://localhost:9000/404/',
     ]
     checker = checkerCls(domain=urlparse(urls[0]).netloc)
+
+    if len(pages_to_check_file) > 0:
+        pages_to_check_reader = ReadInputPages(pages_to_check_file, 'http://localhost:9000/')
+        pages_to_check = pages_to_check_reader.read_input_pages()
+        checker.pages_to_check = pages_to_check
+        urls = urls if len(pages_to_check) == 0 else pages_to_check
+
     for url in urls:
         checker.enqueue(URLReference(ref=url))
 
@@ -231,10 +239,10 @@ def main(checkerCls: CheckerInterface, projdir: str) -> int:
 
 if __name__ == "__main__":
     try:
-        if len(sys.argv) != 2:
+        if len(sys.argv) < 2:
             print(f"Usage: {sys.argv[0]} PROJDIR", file=sys.stderr)
             sys.exit(2)
-        sys.exit(main(AmbassadorChecker, sys.argv[1]))
+        sys.exit(main(AmbassadorChecker, sys.argv[1], sys.argv[2] if len(sys.argv) else ''))
     except KeyboardInterrupt as err:
         print(err, file=sys.stderr)
         sys.exit(130)

--- a/utils/read_input_pages.py
+++ b/utils/read_input_pages.py
@@ -1,0 +1,32 @@
+from typing import List
+
+
+class ReadInputPages:
+    __file_path: str = ""
+    __base_url: str = ""
+
+    def __init__(self, file_path: str, base_url: str):
+        self.__file_path = file_path
+        self.__base_url = base_url
+
+    def read_input_pages(self) -> List:
+        pages_to_check = []
+        try:
+            with open(self.__file_path, mode='r') as input_pages:
+                while line := input_pages.readline():
+                    page_path = self.__parse_file_to_page(line)
+                    pages_to_check.append(page_path)
+        except FileNotFoundError as err:
+            print(f"Is not possible to read the file: {err}")
+            return []
+        return pages_to_check
+
+    def __parse_file_to_page(self, page_path: str) -> str:
+        """
+        Converts a file to path to an address to enqueue in the checker
+        input: ambassador-docs/docs/edge-stack/2.0/howtos/advanced-rate-limiting.md
+        returns: {base_url}/docs/edge-stack/2.0/howtos/advanced-rate-limiting/
+        """
+        page_path = page_path.replace(".md\n", "")
+        page_path = page_path.replace("ambassador-docs/", "")
+        return self.__base_url + page_path


### PR DESCRIPTION
Prio this PR there wasn't a way to check only some pages. Now we can specify what specific pages to check. To do that we use the environment variable PAGES_TO_CHECK which will be the value of the path of a file. 

```
TARGET=~/datawire/getambassador.io PRODUCT=getambassadorio  make -C . PAGES_TO_CHECK=/Users/arturo.gonzalez/datawire/getambassador.io/out.csv
```

The content of the file should be a list of the files to check. The files only must be MD files like this:

```
ambassador-docs/docs/edge-stack/2.0/howtos/advanced-rate-limiting.md
ambassador-docs/docs/edge-stack/pre-release/howtos/advanced-rate-limiting.md
```