### PR TITLE
Parse for telepresence files

### DIFF
--- a/utils/read_input_pages.py
+++ b/utils/read_input_pages.py
@@ -30,4 +30,5 @@ class ReadInputPages:
         """
         page_path = page_path.replace(".md\n", "")
         page_path = page_path.replace("ambassador-docs/", "")
+        page_path = page_path.replace('v', '', 1) if "telepresence" in page_path else page_path
         return self.__base_url + page_path

--- a/utils/read_input_pages.py
+++ b/utils/read_input_pages.py
@@ -30,5 +30,7 @@ class ReadInputPages:
         """
         page_path = page_path.replace(".md\n", "")
         page_path = page_path.replace("ambassador-docs/", "")
-        page_path = page_path.replace('v', '', 1) if "telepresence" in page_path else page_path
+        page_path = (
+            page_path.replace('v', '', 1) if "telepresence" in page_path else page_path
+        )
         return self.__base_url + page_path


### PR DESCRIPTION
This PR adds support to parse the telepresence files. Those files are located outside of the `ambassador-docs` folder and contain a `v` in the version section of the path.