### PR TITLE
remove returning a error when find broken links

### DIFF
--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -234,7 +234,7 @@ def main(checkerCls: CheckerInterface, projdir: str, pages_to_check_file: str) -
     print(
         f"  Results: Encountered {checker.stats_broken_links} errors, {checker.stats_links_bad} bad links."
     )
-    return 1 if len(pages_to_check) > 0 and checker.stats_broken_links > 0 else 0
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this PR, when the blc found a broken link returns an error, now the BLC for getambassador.io completes successfully even when it finds broken links