### PR TITLE
Add user agents for 403 links

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,7 +6,7 @@ black
 mypy
 lxml-stubs
 types-beautifulsoup4
-types-requests
+types-requests==2.25.11
 
 # Other linting
 flake8

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -60,7 +60,6 @@ class AmbassadorChecker(GenericChecker):
         "https://www.comparably.com/news/best-leadership-teams-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
         "https://www.comparably.com/news/best-companies-for-career-growth-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
         "https://www.comparably.com/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
-        "": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     }
 
     def log_broken(self, link: Link, reason: str) -> None:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -189,7 +189,6 @@ class AmbassadorChecker(GenericChecker):
 
 def main(checkerCls: CheckerInterface, projdir: str, pages_to_check_file: str) -> int:
     urls = [
-        'http://localhost:9000/docs/telepresence/',
         'http://localhost:9000/',
         'http://localhost:9000/404.html',
         'http://localhost:9000/404/',

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -189,6 +189,7 @@ class AmbassadorChecker(GenericChecker):
 
 def main(checkerCls: CheckerInterface, projdir: str, pages_to_check_file: str) -> int:
     urls = [
+        'http://localhost:9000/docs/telepresence/'
         'http://localhost:9000/',
         'http://localhost:9000/404.html',
         'http://localhost:9000/404/',

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -54,6 +54,13 @@ class AmbassadorChecker(GenericChecker):
         "https://java.com/en/download/help/download_options.html": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
         "https://java.com/en/download/": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
         "https://tanzu.vmware.com/kubernetes-grid": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+        "https://www.comparably.com/awards/winners/best-company-boston-2022": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://www.comparably.com/news/best-work-life-balance-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://www.comparably.com/news/best-ceos-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://www.comparably.com/news/best-leadership-teams-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://www.comparably.com/news/best-companies-for-career-growth-2021/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "https://www.comparably.com/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     }
 
     def log_broken(self, link: Link, reason: str) -> None:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -189,7 +189,7 @@ class AmbassadorChecker(GenericChecker):
 
 def main(checkerCls: CheckerInterface, projdir: str, pages_to_check_file: str) -> int:
     urls = [
-        'http://localhost:9000/docs/telepresence/'
+        'http://localhost:9000/docs/telepresence/',
         'http://localhost:9000/',
         'http://localhost:9000/404.html',
         'http://localhost:9000/404/',


### PR DESCRIPTION
Add a different user agent for 403 links:

- https://www.comparably.com/awards/winners/best-company-boston-2022
- https://www.comparably.com/news/best-work-life-balance-2021/
- https://www.comparably.com/news/best-ceos-2021/
- https://www.comparably.com/news/best-leadership-teams-2021/
- https://www.comparably.com/news/best-companies-for-career-growth-2021/
- https://www.comparably.com/