### PR TITLE
Aglez/dev/user agent domain validation

### DIFF
--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -8,6 +8,7 @@ from urllib.parse import urldefrag, urlparse
 import bs4.element
 import requests
 import tinycss2
+import urllib3.util
 from bs4 import BeautifulSoup
 from requests.utils import parse_header_links
 
@@ -150,7 +151,8 @@ class BaseChecker:
                     self.enqueue(task)
 
     def _get_user_agent(self, url: str) -> str:
-        return self._user_agent_for_link.get(url, USER_AGENT)
+        domain = urlparse(url).netloc
+        return self._user_agent_for_link.get(domain, USER_AGENT)
 
     def _get_resp(self, url: str) -> Union[requests.Response, str]:
         try:

--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -8,7 +8,6 @@ from urllib.parse import urldefrag, urlparse
 import bs4.element
 import requests
 import tinycss2
-import urllib3.util
 from bs4 import BeautifulSoup
 from requests.utils import parse_header_links
 

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -50,10 +50,11 @@ def link_manually_checked(link: Link) -> bool:
 
 class AmbassadorChecker(GenericChecker):
     _user_agent_for_link: Dict[str, str] = {
-        "https://www.ticketmaster.com/": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
-        "https://java.com/en/download/help/download_options.html": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
-        "https://java.com/en/download/": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
-        "https://tanzu.vmware.com/kubernetes-grid": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+        "www.ticketmaster.com": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "java.com": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+        "tanzu.vmware.com": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+        "help.github.com": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
+        "docs.github.com": "Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0",
     }
 
     def log_broken(self, link: Link, reason: str) -> None:


### PR DESCRIPTION
Prior to this PR, the user agent validation used the entire URL, now the checker uses the domain to validate the user agent. Also, this PR adds the domain `docs.github.com` to this validation.