### PR TITLE
add a link for a manually check

### DIFF
--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -41,7 +41,7 @@ def link_manually_checked(link: Link) -> bool:
         "https://www.comparably.com/news/best-leadership-teams-2021/",
         "https://www.comparably.com/news/best-companies-for-career-growth-2021/",
         "https://www.comparably.com/",
-        "https://comparably.com/"
+        "https://comparably.com/",
     ]
     return (
         len(

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -41,6 +41,7 @@ def link_manually_checked(link: Link) -> bool:
         "https://www.comparably.com/news/best-leadership-teams-2021/",
         "https://www.comparably.com/news/best-companies-for-career-growth-2021/",
         "https://www.comparably.com/",
+        "https://comparably.com/"
     ]
     return (
         len(


### PR DESCRIPTION
This PR adds the site `https://comparably.com/` to the list of links to check manually