### PR TITLE
Add validation for linkedin links

### DIFF
--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -150,7 +150,7 @@ class AmbassadorChecker(GenericChecker):
             )
             or (
                 broken == 'HTTP_999'
-                and link.linkurl.resolved.startswith('https://www.linkedin.com/')
+                and re.search('^https://.+linkedin.com', link.linkurl.resolved)
             )
             or (
                 link.html


### PR DESCRIPTION
There was a validation to check when a link is from linkedin because it always returns a HTTP_999 code although the link works. But that validation were only created to match with urls that start with https://www.linkedin.com/, There are some times where users add links from linkedin but using one from a specific country, for example:

- https://uk.linkedin.com/
- https://ca.linkedin.com/

That's the reason why BLC are reporting those links from linkedin as broken links. With this new validation it doesn't matter if the links is using the global name or a specific country name.

In fact this is the new validation:
_**re.search('^https://.+linkedin.com', link.linkurl.resolved)**_
