### PR TITLE
hotfix: Avoid caching pages that contain arguments because some of them cause a redirect loop.

### DIFF
--- a/blclib/httpcache.py
+++ b/blclib/httpcache.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from typing import Container, Dict, Mapping, Optional, Text, Tuple, Union
-from urllib.parse import urldefrag, urljoin
+from urllib.parse import urldefrag, urljoin, urlparse, parse_qs
 
 import requests
 import requests.adapters
@@ -67,8 +67,11 @@ class HTTPClient(requests.Session):
                     ):
                         raise RetryAfterException(str(req.url), 60)
                     elif cachekey:
-                        client._cache[cachekey] = resp
-
+                        parsed_url = urlparse(req.url)
+                        args = parse_qs(parsed_url.query)
+                        if not resp.is_redirect or "//localhost" in req.url or not args:
+                            client._cache[cachekey] = resp
+                            
                 return resp
 
             def close(self) -> None:

--- a/blclib/httpcache.py
+++ b/blclib/httpcache.py
@@ -68,10 +68,9 @@ class HTTPClient(requests.Session):
                         raise RetryAfterException(str(req.url), 60)
                     elif cachekey:
                         parsed_url = urlparse(req.url)
-                        args = parse_qs(parsed_url.query)
-                        if not resp.is_redirect or "//localhost" in req.url or not args:
+                        args = parse_qs(str(parsed_url.query))
+                        if not resp.is_redirect or "//localhost" in str(req.url) or not args:
                             client._cache[cachekey] = resp
-                            
                 return resp
 
             def close(self) -> None:

--- a/blclib/httpcache.py
+++ b/blclib/httpcache.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from typing import Container, Dict, Mapping, Optional, Text, Tuple, Union
-from urllib.parse import urldefrag, urljoin, urlparse, parse_qs
+from urllib.parse import parse_qs, urldefrag, urljoin, urlparse
 
 import requests
 import requests.adapters

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -30,7 +30,6 @@ def urlpath(url: str) -> str:
 def domains_manually_checked(link: Link) -> bool:
     links_to_check_manually = [
         "https://artifacthub.io/",
-        "https://blog.getambassador.io/"
     ]
     return (
         len(


### PR DESCRIPTION
A validation is added to avoid caching redirect requests that contain arguments, since many times the response url changes depending on this.This because sometimes this issue cause  and infinite redirect loop and
throwing an error ([Exceeded 30 redirects.](https://app.circleci.com/pipelines/github/datawire/getambassador.io/9629/workflows/d3996900-0e7e-4141-b2cd-46026e171b3c/jobs/25167))