### PR TITLE
Exclude /404 from getambassador.io

### DIFF
--- a/blclib/checker.py
+++ b/blclib/checker.py
@@ -212,7 +212,7 @@ class BaseChecker:
             return (
                 "github" in ref.netloc and "." in last_slug and response.status_code == 200
             )
-        except Exception as err:
+        except Exception:
             return False
 
     def _is_link_broken(self, link: Link) -> Optional[str]:

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -214,7 +214,7 @@ class AmbassadorChecker(GenericChecker):
 
     @staticmethod
     def _parse_srcset_value(attrvalue: str) -> List:
-        if attrvalue is None or attrvalue=="":
+        if attrvalue is None or attrvalue == "":
             return []
 
         if (

--- a/getambassadorio_blc.py
+++ b/getambassadorio_blc.py
@@ -139,6 +139,7 @@ class AmbassadorChecker(GenericChecker):
             '/sitemap/sitemap-index.xml',
             '/docs/telepresence/latest/docker/extension/',
             'https://www.googletagmanager.com/ns.html?id=undefined',
+            '/404/',
         ]
         return (
             len([True for link_to_skip in links_to_skip if link.linkurl.ref in link_to_skip])

--- a/mypy-stubs/webencodings/__init__.py
+++ b/mypy-stubs/webencodings/__init__.py
@@ -6,7 +6,7 @@ class Encoding(object):
     codec_info: codecs.CodecInfo
 
     def __init__(self, name: str, codec_info: codecs.CodecInfo) -> None:
-        ...
+        self.name = name
 
     def __repr__(self) -> str:
-        ...
+        return '<Encoding %s>' % self.name


### PR DESCRIPTION
Exclude `/404` form the BLC.  It will fix this error:
https://app.circleci.com/pipelines/github/datawire/getambassador.io/13254/workflows/2de719a7-25ed-46b1-8b63-45dbea23b0aa/jobs/39640?invite=true#step-110-24213_43